### PR TITLE
one pass blur

### DIFF
--- a/src/gpu_resources.rs
+++ b/src/gpu_resources.rs
@@ -107,8 +107,7 @@ pub fn prepare_gpu_resources(
 pub struct Lighting2dSurfaceBindGroups {
     pub sdf: BindGroup,
     pub lighting: BindGroup,
-    pub blur_x: BindGroup,
-    pub blur_y: BindGroup,
+    pub blur: BindGroup,
 }
 
 pub fn prepare_lighting_bind_groups(
@@ -159,23 +158,13 @@ pub fn prepare_lighting_bind_groups(
                     &sampler,
                 )),
             ),
-            blur_x: render_device.create_bind_group(
-                "blur_x_bind_group",
+            blur: render_device.create_bind_group(
+                "blur_bind_group",
                 &prepass_pipelines.blur_layout,
                 &BindGroupEntries::sequential((
                     view_uniform.clone(),
                     lighting_settings.clone(),
                     &aux_textures.lighting.default_view,
-                    &sampler,
-                )),
-            ),
-            blur_y: render_device.create_bind_group(
-                "blur_y_bind_group",
-                &prepass_pipelines.blur_layout,
-                &BindGroupEntries::sequential((
-                    view_uniform.clone(),
-                    lighting_settings.clone(),
-                    &aux_textures.blur_x.default_view,
                     &sampler,
                 )),
             ),
@@ -231,8 +220,7 @@ fn create_aux_texture(
 pub struct Lighting2dAuxiliaryTextures {
     pub sdf: CachedTexture,
     pub lighting: CachedTexture,
-    pub blur_x: CachedTexture,
-    pub blur_y: CachedTexture,
+    pub blur: CachedTexture,
 }
 
 pub fn prepare_lighting_auxiliary_textures(
@@ -250,8 +238,7 @@ pub fn prepare_lighting_auxiliary_textures(
                 &render_device,
                 "lighting",
             ),
-            blur_x: create_aux_texture(view_target, &mut texture_cache, &render_device, "blur_x"),
-            blur_y: create_aux_texture(view_target, &mut texture_cache, &render_device, "blur_y"),
+            blur: create_aux_texture(view_target, &mut texture_cache, &render_device, "blur"),
         });
     }
 }

--- a/src/shaders/blur.wgsl
+++ b/src/shaders/blur.wgsl
@@ -8,26 +8,19 @@
 @group(0) @binding(3) var texture_sampler: sampler;
 
 @fragment
-fn blur_x(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return blur(in.position, vec2(1.0, 0.0));
-}
-
-@fragment
-fn blur_y(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
-    return blur(in.position, vec2(0.0, 1.0));
-}
-
-fn blur(frag_coord: vec4<f32>, frag_offset: vec2<f32>) -> vec4<f32> {
+fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     var coc = settings.coc;
 
     if !bool(settings.fixed_resolution) {
         let screen_size = view.viewport.zw;
         let screen_diagonal = sqrt(pow(screen_size.x + screen_size.y, 2.0));
-
         coc *= screen_diagonal / 2000.0;
     }
 
-    return gaussian_blur(frag_coord, coc, frag_offset);
+    let x = gaussian_blur(in.position, coc, vec2(1.0, 0.0));
+    let y = gaussian_blur(in.position, coc, vec2(0.0, 1.0));
+
+    return mix(x, y, 0.5);
 }
 
 // ATTRIBUTION: The code for this function was originally


### PR DESCRIPTION
I assumed we needed a second pass for the blur because of how bevy implements depth of fields, but we can actually do it in just one. Maybe I'm missing something here, are there any performance implications in doing it in a single pass?